### PR TITLE
Use HTTPS for API calls

### DIFF
--- a/lib/plos/client.rb
+++ b/lib/plos/client.rb
@@ -6,7 +6,7 @@ module PLOS
     attr_accessor :api_key
     attr_accessor :base_url
 
-    def initialize(api_key, base_url="http://api.plos.org")
+    def initialize(api_key, base_url="https://api.plos.org")
       self.api_key = api_key
       self.base_url = base_url
     end

--- a/spec/plos_spec.rb
+++ b/spec/plos_spec.rb
@@ -6,17 +6,17 @@ describe PLOS do
     let(:client) { client = PLOS::Client.new("API_KEY") }
 
     it "should call the correct search url" do
-      RestClient.should_receive(:post).with("http://api.plos.org/search", {:api_key=>"API_KEY", :q=>"xenograft", :rows=>50, :start=>0}).and_return("")
+      RestClient.should_receive(:post).with("https://api.plos.org/search", {:api_key=>"API_KEY", :q=>"xenograft", :rows=>50, :start=>0}).and_return("")
       client.search("xenograft")
     end
 
     it "should call the correct search url when rows and start are specified" do
-      RestClient.should_receive(:post).with("http://api.plos.org/search", {:api_key=>"API_KEY", :q=>"xenograft", :rows=>100, :start=>200}).and_return("")
+      RestClient.should_receive(:post).with("https://api.plos.org/search", {:api_key=>"API_KEY", :q=>"xenograft", :rows=>100, :start=>200}).and_return("")
       client.search("xenograft", 200, 100)
     end
 
     it "should call the correct search url when finding all" do
-      RestClient.should_receive(:post).with("http://api.plos.org/search", {:api_key=>"API_KEY", :q=>"*:*", :rows=>50, :start=>0}).and_return("")
+      RestClient.should_receive(:post).with("https://api.plos.org/search", {:api_key=>"API_KEY", :q=>"*:*", :rows=>50, :start=>0}).and_return("")
       client.all
     end
 


### PR DESCRIPTION
HTTP returns a "308 Permanent Redirect" and the client raises an error.